### PR TITLE
Add function to balance the catalog across the ranks

### DIFF
--- a/mpytools/catalog.py
+++ b/mpytools/catalog.py
@@ -909,8 +909,20 @@ class BaseCatalog(BaseClass):
         mpsort.sort(array, orderby=orderby, out=out)
         new = self.copy()
         new.data = BaseCatalog.from_array(out, mpicomm=self.mpicomm).data
+        
         return new
 
+    def balance_across_rank(self):
+        """
+        Return new catalog with roughly similar size on each rank. mpicomm not expected to be None.
+        Note: In specific case, can produce unbalanced catalog (typically, when size < mpicomm.size ..)
+        """
+
+        self['index'] = np.arange(self.size) % self.mpicomm.size
+        new = self.csort('index', size='orderby_counts')
+        new.__delitem__('index')
+        
+        return new
 
 class Catalog(BaseCatalog):
 


### PR DESCRIPTION
I'm adding a function I often need that balance the data across the different ranks (in particular after geometrical selections, it is commun to have rank without data. This break the kmeans step in pycorr for jackknife for instance). 

This uses the function csort that we implemented earlier, so nothing new, just convenient.

